### PR TITLE
Fix build on systems where make is not a GNU make.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,12 @@ unless defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
       if !File.directory?("vendor/hiredis/.git")
         system("git submodule update --init")
       end
-      system("cd vendor/hiredis && make clean")
+      gnu_make = system("make --version 2>/dev/null | grep 'GNU Make' > /dev/null")
+      if gnu_make
+        system("cd vendor/hiredis && make clean")
+      else
+        system("cd vendor/hiredis && gmake clean")
+      end
     end
   end
 

--- a/ext/hiredis_ext/extconf.rb
+++ b/ext/hiredis_ext/extconf.rb
@@ -9,7 +9,12 @@ unless File.directory?(hiredis_dir)
 end
 
 # Make sure hiredis is built...
-system("cd #{hiredis_dir} && make static")
+gnu_make = system("make --version 2>/dev/null | grep 'GNU Make' > /dev/null")
+if gnu_make
+  system("cd #{hiredis_dir} && make static")
+else
+  system("cd #{hiredis_dir} && gmake static")
+end
 
 # Statically link to hiredis (mkmf can't do this for us)
 $CFLAGS << " -I#{hiredis_dir}"


### PR DESCRIPTION
This patch fixes build on systems where GNU make is not default (e.g. FreeBSD).
On these systems GNU make is usually installed as `gmake'.
