### PR TITLE
Improve Rubinius support in hiredis

### DIFF
--- a/ext/hiredis_ext/hiredis_ext.c
+++ b/ext/hiredis_ext/hiredis_ext.c
@@ -8,6 +8,8 @@ VALUE mod_ext;
 void Init_hiredis_ext() {
     mod_hiredis = rb_define_module("Hiredis");
     mod_ext = rb_define_module_under(mod_hiredis,"Ext");
+    rb_global_variable(&mod_hiredis);
+    rb_global_variable(&mod_ext);
     InitReader(mod_ext);
     InitConnection(mod_ext);
 }

--- a/ext/hiredis_ext/hiredis_ext.h
+++ b/ext/hiredis_ext/hiredis_ext.h
@@ -1,6 +1,13 @@
 #ifndef __HIREDIS_EXT_H
 #define __HIREDIS_EXT_H
 
+/* Defined for Rubinius. This indicates a char* obtained
+ * through RSTRING_PTR is never modified in place. With this
+ * define Rubinius can disable the slow copy back mechanisms
+ * to make sure strings are updated at the Ruby side.
+ */
+#define RSTRING_NOT_MODIFIED
+
 #include "hiredis.h"
 #include "ruby.h"
 

--- a/ext/hiredis_ext/reader.c
+++ b/ext/hiredis_ext/reader.c
@@ -97,6 +97,7 @@ static VALUE reader_gets(VALUE klass) {
 VALUE klass_reader;
 void InitReader(VALUE mod) {
     klass_reader = rb_define_class_under(mod, "Reader", rb_cObject);
+    rb_global_variable(&klass_reader);
     rb_define_alloc_func(klass_reader, reader_allocate);
     rb_define_method(klass_reader, "feed", reader_feed, 1);
     rb_define_method(klass_reader, "gets", reader_gets, 0);
@@ -108,6 +109,7 @@ void InitReader(VALUE mod) {
         enc_klass = rb_const_get(rb_cObject, rb_intern("Encoding"));
         enc_default_external = rb_intern("default_external");
         str_force_encoding = rb_intern("force_encoding");
+        rb_global_variable(&enc_klass);
     } else {
         enc_default_external = 0;
     }


### PR DESCRIPTION
When profiling a Sidekiq app, this showed a few places in hiredis that
could be changed with not affecting MRI in a bad way, but improving
performance on Rubinius.

Because Rubinius has a generational garbage collector, writes to an
array need to go through a write barrier. If a C extension uses
RARRAY_PTR, this works around the barrier. For this, Rubinius has to
setup additional support by scanning the whole array when returning from
a C extension function call. This mechanism is only activated when
RARRAY_PTR is used.

By not using this but by using the normal array accessor functions, this
is prevented. On MRI using these functions or RARRAY_PTR don't make any
significant difference.

For strings Rubinius uses a similar mechanisms if extensions modify a
char\* if data is modified directly. To disable this copying back there
is a define that can be used to disable it. Since hiredis-rb doesn't
seem to be modyfing buffers obtained with RSTRING_PTR, I've also enabled
this optimization.

Since for Ruby 2.1, MRI is also working on a generational GC, this can
also potentially be an improved for newer versions of MRI if they choose
to use similar mechanisms for optimizations.

This also marks a few global variables that the gem defines as actual
globals so they don't get accidentally garbage collected.
