### PR TITLE
Remove deprecated rb_tread_select in favor of rb_fd_select

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/hiredis"]
 	path = vendor/hiredis
-	url = git://github.com/antirez/hiredis.git
+	url = git://github.com/redis/hiredis.git

--- a/ext/hiredis_ext/connection.c
+++ b/ext/hiredis_ext/connection.c
@@ -72,24 +72,31 @@ static VALUE connection_parent_context_alloc(VALUE klass) {
     return Data_Wrap_Struct(klass, parent_context_mark, parent_context_free, pc);
 }
 
+void
+init_set_fd(int fd, rb_fdset_t *fds)
+{
+  rb_fd_init(fds);
+  rb_fd_set(fd, fds);
+}
+
+
 static int __wait_readable(int fd, const struct timeval *timeout, int *isset) {
     struct timeval to;
     struct timeval *toptr = NULL;
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(fd, &fds);
+    rb_fdset_t fds;
+    init_set_fd(fd, &fds);
 
-    /* rb_thread_select modifies the passed timeval, so we pass a copy */
+    /* rb_fd_select modifies the passed timeval, so we pass a copy */
     if (timeout != NULL) {
         memcpy(&to, timeout, sizeof(to));
         toptr = &to;
     }
 
-    if (rb_thread_select(fd + 1, &fds, NULL, NULL, toptr) < 0) {
+    if (rb_fd_select(fd + 1, &fds, NULL, NULL, toptr) < 0) {
         return -1;
     }
 
-    if (FD_ISSET(fd, &fds) && isset) {
+    if (rb_fd_isset(fd, &fds) && isset) {
         *isset = 1;
     }
 
@@ -99,21 +106,20 @@ static int __wait_readable(int fd, const struct timeval *timeout, int *isset) {
 static int __wait_writable(int fd, const struct timeval *timeout, int *isset) {
     struct timeval to;
     struct timeval *toptr = NULL;
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(fd, &fds);
+    rb_fdset_t fds;
+    init_set_fd(fd, &fds);
 
-    /* rb_thread_select modifies the passed timeval, so we pass a copy */
+    /* rb_fd_select modifies the passed timeval, so we pass a copy */
     if (timeout != NULL) {
         memcpy(&to, timeout, sizeof(to));
         toptr = &to;
     }
 
-    if (rb_thread_select(fd + 1, NULL, &fds, NULL, toptr) < 0) {
+    if (rb_fd_select(fd + 1, NULL, &fds, NULL, toptr) < 0) {
         return -1;
     }
 
-    if (FD_ISSET(fd, &fds) && isset) {
+    if (rb_fd_isset(fd, &fds) && isset) {
         *isset = 1;
     }
 


### PR DESCRIPTION
rb_thread_select uses select instead of poll, which is less webscale, more
importantly it will removed soon enough
https://bugs.ruby-lang.org/issues/9502#change-45212

ping @pietern

/cc @csfrancis @Sirupsen @fbogsany
