### PR TITLE
Use netcat in test instead of nc

### DIFF
--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -14,7 +14,7 @@ module ConnectionTests
   end
 
   def listen(port = DEFAULT_PORT)
-    IO.popen("nc -l #{port}", "r+") do |io|
+    IO.popen("netcat -l -p #{port}", "r+") do |io|
       sleep 0.1 # Give nc a little time to start listening
 
       begin


### PR DESCRIPTION
The `nc` command is different on linux and BSD. This change requires a Mac user to install gnu netcat (ie via homebrew `brew install netcat`).

I'm unable to run the tests on my ArchLinux desktop or Mavricks MacBook Pro due to this. I just get "Connection Refused" because `nc` is listening on a random port, not 6380.
