### PR TITLE
Added threadsafe support with Hiredis::ThreadSafeConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ the Ruby built-in `Errno::XYZ` errors will be raised. All other errors
 You can skip loading everything and just load `Hiredis::Connection` by
 requiring `hiredis/connection`.
 
+### Standalone: Thread Safe Connection
+If you want to use `Hiredis::Connection` in a multi-threaded environment, replace `Hiredis::Connection` with `Hiredis::ThreadSafeConnection`.  All threads have their own independent pipeline; e.g. sending a write on one thread, and a read on another will just cause the second thread to block. 
+
+``` ruby
+conn = Hiredis::ThreadSafeConnection.new
+conn.connect("127.0.0.1", 6379)
+Thread.new do
+  conn.write ["SET", "hello", "world"]
+end
+```
+
+Connections can be created lazily, but this can be prevented by persisting your thread pool and passing the optional argument `standby_pool_size` to ``Hiredis::ThreadSafeConnection``.  The example below would create 16 connections on initializations and then pass those connections to threads when they first request a write or read.  Note that if you do not persist your threads, this pool will quickly run out and ``Hiredis::ThreadSafeConnection`` will be forced to dynamically connect.
+
+``` ruby
+conn = Hiredis::ThreadSafeConnection standby_pool_size: 16
+conn.connect("127.0.0.1", 6379)
+```
+
+
 ### Standalone: Reply parser
 
 Only using hiredis for the reply parser can be very useful in scenarios

--- a/lib/hiredis.rb
+++ b/lib/hiredis.rb
@@ -1,2 +1,3 @@
 require "hiredis/version"
 require "hiredis/connection"
+require "hiredis/thread_safe_connection"

--- a/lib/hiredis/thread_safe_connection.rb
+++ b/lib/hiredis/thread_safe_connection.rb
@@ -1,0 +1,56 @@
+module Hiredis
+  class ThreadSafeConnection
+    #Spin up 8 threads by default, lazy loading is available, but this can make applications more deterministic
+    STANDBY_POOL_SIZE_DEFAULT = 8
+    def initialize params={}
+      @standby_pool_size = params[:standby_pool_size] || STANDBY_POOL_SIZE_DEFAULT
+    end
+
+    def connect *args
+      if @conns
+        raise "You cannot call connect multiple times on Hiredis::ThreadSafeConnection, please create a new instance if you required this capability"
+      end
+      @args = args
+      @conns = {}
+
+      @standby_pool = []
+      @standby_pool_size.times do
+        conn = Hiredis::Connection.new
+        conn.connect(*@args)
+        @standby_pool << conn
+      end
+    end
+
+    def client
+      current_thread_id = Thread.current.object_id
+      cached_client = @conns[current_thread_id]
+
+      return cached_client if cached_client
+
+      conn = @standby_pool.pop
+
+      #Ran out of connections in the original pool
+      if conn.nil?
+        conn = Hiredis::Connection.new
+        conn.connect(*@args)
+      end
+
+      @conns[current_thread_id] = conn
+
+      return conn
+    end
+
+    def method_missing method, *args, &block
+      $stderr.puts "WARN: Implementors: please implement #{method.inspect} for Hiredis::ThreadSafeConnection, proxying method for now to Hiredis::Connection"
+      self.client.send(method, *args, &block)
+    end
+
+    def write args
+      self.client.write args
+    end
+
+    def read
+      self.client.read
+    end
+  end
+end


### PR DESCRIPTION
Allows Hiredis to support multi-threaded environments by automatically creating a Redis::Connection for each unique thread.  Supports warming up threads via optional :standby_pool_size option, see changes to read me for usage.
