### PR TITLE
Foiling CG

### DIFF
--- a/ext/hiredis_ext/connection.c
+++ b/ext/hiredis_ext/connection.c
@@ -27,7 +27,8 @@ static void parent_context_try_free(redisParentContext *pc) {
 }
 
 static void parent_context_mark(redisParentContext *pc) {
-    VALUE root;
+    // volatile until rb_gc_mark
+    volatile VALUE root;
     if (pc->context && pc->context->reader) {
         root = (VALUE)redisReplyReaderGetObject(pc->context->reader);
         if (root != 0 && TYPE(root) == T_ARRAY) {
@@ -448,7 +449,7 @@ static int __get_reply(redisParentContext *pc, VALUE *reply) {
 
 static VALUE connection_read(VALUE self) {
     redisParentContext *pc;
-    VALUE reply;
+    volatile VALUE reply;
 
     Data_Get_Struct(self,redisParentContext,pc);
     if (!pc->context)


### PR DESCRIPTION
Made most VALUE variables volatile to stop them from being GCed until they are off the stack.

I probably changed a couple that did not need to be changed but making the variable volatile will not hurt anything. What it does is stop the compiler from optimizing those variable into registers when Ruby does not see them. They remain on the stack and Ruby will not CG them until they are no longer on the stack.

I also left a FIXME comment related to the redisreaderi->reply use. It might be worth doing a double check.