### PR TITLE
Don't attempt to build the C extension on unsupported platforms

### DIFF
--- a/ext/hiredis_ext/extconf.rb
+++ b/ext/hiredis_ext/extconf.rb
@@ -1,5 +1,12 @@
 require 'mkmf'
 
+build_hiredis = true
+unless have_header('sys/socket.h')
+  puts "Could not find <sys/socket.h> (Likely Windows)."
+  puts "Skipping building hiredis. The slower, pure-ruby implementation will be used instead."
+  build_hiredis = false
+end
+
 RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 
 hiredis_dir = File.join(File.dirname(__FILE__), %w{.. .. vendor hiredis})
@@ -19,15 +26,23 @@ else
   'make'
 end
 
-# Make sure hiredis is built...
-Dir.chdir(hiredis_dir) do
-  success = system("#{make_program} static")
-  raise "Building hiredis failed" if !success
+if build_hiredis
+  # Make sure hiredis is built...
+  Dir.chdir(hiredis_dir) do
+    success = system("#{make_program} static")
+    raise "Building hiredis failed" if !success
+  end
+
+  # Statically link to hiredis (mkmf can't do this for us)
+  $CFLAGS << " -I#{hiredis_dir}"
+  $LDFLAGS << " #{hiredis_dir}/libhiredis.a"
+
+  have_func("rb_thread_fd_select")
+  create_makefile('hiredis/ext/hiredis_ext')
+else
+  File.open("Makefile", "wb") do |f|
+    dummy_makefile(".").each do |line|
+      f.puts(line)
+    end
+  end
 end
-
-# Statically link to hiredis (mkmf can't do this for us)
-$CFLAGS << " -I#{hiredis_dir}"
-$LDFLAGS << " #{hiredis_dir}/libhiredis.a"
-
-have_func("rb_thread_fd_select")
-create_makefile('hiredis/ext/hiredis_ext')


### PR DESCRIPTION
hiredis doesn't support Windows at the moment. It is possible to get it
to compile in some cygwin environments, but that may not be the
environment the user is on. This attempts to detect if hiredis would
build successfully, and skips building the native extension on those
platforms. This means that hiredis will fall back to the slower
implementation. This is fine for developers getting started, and if
speed is a requirement, the user can modify their build environment to
build the C extension.

While this case likely means Windows, the implementation doesn't care,
and skips all environments without `socket.h`