### PR TITLE
CI: Add latest Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ rvm:
   - 2.1.10
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - ruby-2.6.0-preview2
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - ruby-2.7.0-preview2
   - jruby-19mode
 
 notifications:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known