### PR TITLE
AppVeyor: Use Bundler 1.17.3 to fix the build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - ruby --version
   - ruby -e 'p([:engine, RUBY_ENGINE, :platform, RUBY_PLATFORM])'
   - gem --version
-  - gem install bundler --no-document
+  - gem install bundler:1.17.3 --no-document
   - bundler --version
   - bundle install --retry=3
 


### PR DESCRIPTION
This PR **uses Bundler v1.17.3**, which is accepted by the Windows Ruby versions configured in AppVeyor.

Fixes #65 and now we are 📗 🍏 💚 green again.