### PR TITLE
Bump hiredis to v1.0.0

### DIFF
--- a/ext/hiredis_ext/reader.c
+++ b/ext/hiredis_ext/reader.c
@@ -34,7 +34,7 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
     return tryParentize(task,v);
 }
 
-static void *createArrayObject(const redisReadTask *task, int elements) {
+static void *createArrayObject(const redisReadTask *task, size_t elements) {
     volatile VALUE v = rb_ary_new2(elements);
     return tryParentize(task,v);
 }
@@ -57,7 +57,9 @@ redisReplyObjectFunctions redisExtReplyObjectFunctions = {
     createStringObject,
     createArrayObject,
     createIntegerObject,
+    NULL,
     createNilObject,
+    NULL,
     freeObject
 };
 


### PR DESCRIPTION
According to hiredis readme, there's only a handful of breaking changes.

https://github.com/redis/hiredis/blob/297f6551da11d4a22fefe4d385d42edf27a6cd73/README.md

> IMPORTANT: Breaking changes from 0.14.1 -> 1.0.0
> 
>     redisContext has two additional members (free_privdata, and privctx).
>     redisOptions.timeout has been renamed to redisOptions.connect_timeout, and we've added redisOptions.command_timeout.
>     redisReplyObjectFunctions.createArray now takes size_t instead of int for its length parameter.

This PR:
- bumps hiredis to the head of v1.0.0 tag
- stubs [RESP3](https://github.com/antirez/RESP3/blob/master/spec.md#resp3-types) protocol reply functions (double and bool) 
- updates createArrayObject signature 