### PR TITLE
Add possibility to connect to elasticache using ssl

### DIFF
--- a/ext/hiredis_ext/extconf.rb
+++ b/ext/hiredis_ext/extconf.rb
@@ -29,13 +29,19 @@ end
 if build_hiredis
   # Make sure hiredis is built...
   Dir.chdir(hiredis_dir) do
-    success = system("#{make_program} static")
-    raise "Building hiredis failed" if !success
+    success = system("USE_SSL=1 #{make_program}")
+    raise "Building hiredis failed" unless success
   end
 
   # Statically link to hiredis (mkmf can't do this for us)
   $CFLAGS << " -I#{hiredis_dir}"
+  $CFLAGS << " -I/usr/local/opt/openssl/include"
+
   $LDFLAGS << " #{hiredis_dir}/libhiredis.a"
+  $LDFLAGS << " #{hiredis_dir}/libhiredis_ssl.a"
+  $LDFLAGS << " -L/usr/local/opt/openssl/lib"
+  $LDFLAGS << " -lssl"
+  $LDFLAGS << " -lcrypto"
 
   have_func("rb_thread_fd_select")
   create_makefile('hiredis/ext/hiredis_ext')

--- a/ext/hiredis_ext/hiredis_ext.h
+++ b/ext/hiredis_ext/hiredis_ext.h
@@ -8,7 +8,12 @@
  */
 #define RSTRING_NOT_MODIFIED
 
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
 #include "hiredis.h"
+#include "hiredis_ssl.h"
+
 #include "ruby.h"
 
 /* Defined in hiredis_ext.c */

--- a/ext/hiredis_ext/reader.c
+++ b/ext/hiredis_ext/reader.c
@@ -34,7 +34,7 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
     return tryParentize(task,v);
 }
 
-static void *createArrayObject(const redisReadTask *task, int elements) {
+static void *createArrayObject(const redisReadTask *task, size_t elements) {
     volatile VALUE v = rb_ary_new2(elements);
     return tryParentize(task,v);
 }
@@ -57,7 +57,9 @@ redisReplyObjectFunctions redisExtReplyObjectFunctions = {
     createStringObject,
     createArrayObject,
     createIntegerObject,
+    NULL,
     createNilObject,
+    NULL,
     freeObject
 };
 


### PR DESCRIPTION
This PR adds possibility to connect to ElastiCache with enabled SSL. 

What was done:
- hiredis submodule was bumped to version 1.0.0
- C extension in hiredis-rb was extended to support SSL connection without certification

To establish SSL connection with SSL_VERIFY_NONE:
```
require 'hiredis'

conn = Hiredis::Connection.new
conn.connect_ssl('<host>', 6379)

conn.write %w[AUTH <password>]
puts conn.read
conn.write %w[SET speed awesome]
puts conn.read
conn.write %w[GET speed]
puts conn.read
```