### PR TITLE
Add possibility to establish SSL connection with SSL_VERIFY_NONE

### DIFF
--- a/ext/hiredis_ext/connection.c
+++ b/ext/hiredis_ext/connection.c
@@ -320,6 +320,7 @@ static VALUE connection_connect_ssl(int argc, VALUE *argv, VALUE self) {
 
     redisOptions options = {0};
     REDIS_OPTIONS_SET_TCP(&options, StringValuePtr(arg_host), NUM2INT(arg_port));
+    options.options |= REDIS_OPT_NONBLOCK;
     options.connect_timeout = timeout;
     c = redisConnectWithOptions(&options);
 

--- a/ext/hiredis_ext/connection.c
+++ b/ext/hiredis_ext/connection.c
@@ -2,6 +2,14 @@
 #include <errno.h>
 #include "hiredis_ext.h"
 
+struct redisSSLContext {
+    /* Associated OpenSSL SSL_CTX as created by redisCreateSSLContext() */
+    SSL_CTX *ssl_ctx;
+
+    /* Requested SNI, or NULL */
+    char *server_name;
+};
+
 typedef struct redisParentContext {
     redisContext *context;
     struct timeval *timeout;
@@ -242,6 +250,9 @@ static VALUE connection_connect(int argc, VALUE *argv, VALUE self) {
     VALUE arg_port = Qnil;
     VALUE arg_timeout = Qnil;
 
+    struct timeval tv;
+    struct timeval *timeout = NULL;
+
     if (argc == 2 || argc == 3) {
         arg_host = argv[0];
         arg_port = argv[1];
@@ -253,13 +264,80 @@ static VALUE connection_connect(int argc, VALUE *argv, VALUE self) {
             if (NUM2INT(arg_timeout) <= 0) {
                 rb_raise(rb_eArgError, "timeout should be positive");
             }
+
+            tv.tv_sec = NUM2INT(arg_timeout) / 1000000;
+            tv.tv_usec = NUM2INT(arg_timeout) % 1000000;
+            timeout = &tv;
         }
     } else {
         rb_raise(rb_eArgError, "invalid number of arguments");
     }
 
-    c = redisConnectNonBlock(StringValuePtr(arg_host), NUM2INT(arg_port));
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, StringValuePtr(arg_host), NUM2INT(arg_port));
+    options.options |= REDIS_OPT_NONBLOCK;
+    options.connect_timeout = timeout;
+    c = redisConnectWithOptions(&options);
+
     return connection_generic_connect(self,c,arg_timeout);
+}
+
+static VALUE connection_connect_ssl(int argc, VALUE *argv, VALUE self) {
+    redisContext *c;
+    VALUE arg_host = Qnil;
+    VALUE arg_port = Qnil;
+    VALUE arg_timeout = Qnil;
+
+    struct timeval tv;
+    struct timeval *timeout = NULL;
+
+    redisSSLContext *ssl;
+    redisSSLContextError ssl_error;
+
+    if (argc == 2 || argc == 3) {
+        arg_host = argv[0];
+        arg_port = argv[1];
+
+        if (argc == 3) {
+            arg_timeout = argv[2];
+
+            /* Sanity check */
+            if (NUM2INT(arg_timeout) <= 0) {
+                rb_raise(rb_eArgError, "timeout should be positive");
+            }
+
+            tv.tv_sec = NUM2INT(arg_timeout) / 1000000;
+            tv.tv_usec = NUM2INT(arg_timeout) % 1000000;
+            timeout = &tv;
+        }
+    } else {
+        rb_raise(rb_eArgError, "invalid number of arguments");
+    }
+
+    redisInitOpenSSL();
+    ssl = redisCreateSSLContext(NULL, NULL, NULL, NULL, StringValuePtr(arg_host), &ssl_error);
+    SSL_CTX_set_verify(ssl->ssl_ctx, SSL_VERIFY_NONE, NULL);
+
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, StringValuePtr(arg_host), NUM2INT(arg_port));
+    options.connect_timeout = timeout;
+    c = redisConnectWithOptions(&options);
+
+    if (c == NULL || c->err) {
+        if (c) {
+            redisFree(c);
+            rb_raise(rb_eRuntimeError, "Basic connection to Redis failed! Error: %s\n", c->errstr);
+        } else {
+            rb_raise(rb_eRuntimeError, "Basic connection to Redis failed! Error: can't allocate redis context");
+        }
+    }
+
+    if (redisInitiateSSLWithContext(c, ssl) != REDIS_OK) {
+        redisFree(c);
+        rb_raise(rb_eRuntimeError, "SSL connection to Redis failed! Error: %s\n", c->errstr);
+    }
+
+    return connection_generic_connect(self, c, arg_timeout);
 }
 
 static VALUE connection_connect_unix(int argc, VALUE *argv, VALUE self) {
@@ -503,6 +581,7 @@ void InitConnection(VALUE mod) {
     rb_global_variable(&klass_connection);
     rb_define_alloc_func(klass_connection, connection_parent_context_alloc);
     rb_define_method(klass_connection, "connect", connection_connect, -1);
+    rb_define_method(klass_connection, "connect_ssl", connection_connect_ssl, -1);
     rb_define_method(klass_connection, "connect_unix", connection_connect_unix, -1);
     rb_define_method(klass_connection, "connected?", connection_is_connected, 0);
     rb_define_method(klass_connection, "disconnect", connection_disconnect, 0);

--- a/ext/hiredis_ext/extconf.rb
+++ b/ext/hiredis_ext/extconf.rb
@@ -29,13 +29,19 @@ end
 if build_hiredis
   # Make sure hiredis is built...
   Dir.chdir(hiredis_dir) do
-    success = system("#{make_program} static")
-    raise "Building hiredis failed" if !success
+    success = system("USE_SSL=1 #{make_program}")
+    raise "Building hiredis failed" unless success
   end
 
   # Statically link to hiredis (mkmf can't do this for us)
   $CFLAGS << " -I#{hiredis_dir}"
+  $CFLAGS << " -I/usr/local/opt/openssl/include"
+
   $LDFLAGS << " #{hiredis_dir}/libhiredis.a"
+  $LDFLAGS << " #{hiredis_dir}/libhiredis_ssl.a"
+  $LDFLAGS << " -L/usr/local/opt/openssl/lib"
+  $LDFLAGS << " -lssl"
+  $LDFLAGS << " -lcrypto"
 
   have_func("rb_thread_fd_select")
   create_makefile('hiredis/ext/hiredis_ext')

--- a/ext/hiredis_ext/hiredis_ext.h
+++ b/ext/hiredis_ext/hiredis_ext.h
@@ -8,7 +8,12 @@
  */
 #define RSTRING_NOT_MODIFIED
 
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
 #include "hiredis.h"
+#include "hiredis_ssl.h"
+
 #include "ruby.h"
 
 /* Defined in hiredis_ext.c */

--- a/ext/hiredis_ext/reader.c
+++ b/ext/hiredis_ext/reader.c
@@ -44,8 +44,17 @@ static void *createIntegerObject(const redisReadTask *task, long long value) {
     return tryParentize(task,v);
 }
 
+static void *createDoubleObject(const redisReadTask *task, double value, char *str, size_t len) {
+    volatile VALUE v = DBL2NUM(value);
+    return tryParentize(task,v);
+}
+
 static void *createNilObject(const redisReadTask *task) {
     return tryParentize(task,Qnil);
+}
+
+static void *createBoolObject(const redisReadTask *task, int bval) {
+    return bval == 0 ? tryParentize(task,Qfalse) : tryParentize(task,Qtrue);
 }
 
 static void freeObject(void *ptr) {
@@ -57,9 +66,9 @@ redisReplyObjectFunctions redisExtReplyObjectFunctions = {
     createStringObject,
     createArrayObject,
     createIntegerObject,
-    NULL,
+    createDoubleObject,
     createNilObject,
-    NULL,
+    createBoolObject,
     freeObject
 };
 

--- a/ext/hiredis_ext/reader.c
+++ b/ext/hiredis_ext/reader.c
@@ -34,7 +34,7 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
     return tryParentize(task,v);
 }
 
-static void *createArrayObject(const redisReadTask *task, int elements) {
+static void *createArrayObject(const redisReadTask *task, size_t elements) {
     volatile VALUE v = rb_ary_new2(elements);
     return tryParentize(task,v);
 }
@@ -57,7 +57,9 @@ redisReplyObjectFunctions redisExtReplyObjectFunctions = {
     createStringObject,
     createArrayObject,
     createIntegerObject,
+    NULL,
     createNilObject,
+    NULL,
     freeObject
 };
 

--- a/lib/hiredis/version.rb
+++ b/lib/hiredis/version.rb
@@ -1,3 +1,3 @@
 module Hiredis
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end


### PR DESCRIPTION
This PR adds possibility to establish SSL connection to Redis with SSL_VERIFY_NONE(in my case to ElastiCache).

What was done:
- hiredis submodule was bumped to version 1.0.0
- C extension in hiredis-rb was extended to support SSL connection without certification

```
require 'hiredis'

conn = Hiredis::Connection.new
conn.connect_ssl('<host>', 6379)

conn.write %w[AUTH <password>]
puts conn.read
conn.write %w[SET speed awesome]
puts conn.read
conn.write %w[GET speed]
puts conn.read
```