### PR TITLE
Fix "warning instance variable @sock not defined"

### DIFF
--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -15,6 +15,7 @@ module ConnectionTests
   class Netcat
     def initialize(port)
       @listener = TCPServer.new(port)
+      @sock = nil
     end
 
     def close


### PR DESCRIPTION
Running `bundle exec rake` results in many warnings:

```
test/connection_test.rb:62: warning: instance variable @sock not initialized
```