### PR TITLE
Support SSL connections

### DIFF
--- a/ext/hiredis_ext/connection.c
+++ b/ext/hiredis_ext/connection.c
@@ -279,7 +279,7 @@ static VALUE connection_connect_ssl(int argc, VALUE *argv, VALUE self) {
     VALUE client_key = Qnil;
 
     redisSSLContext *ssl_context;
-    redisSSLContextError ssl_error;
+    redisSSLContextError ssl_error = REDIS_SSL_CTX_NONE;
 
     if (argc >= 2 && argc <= 4) {
         arg_host = argv[0];
@@ -319,7 +319,7 @@ static VALUE connection_connect_ssl(int argc, VALUE *argv, VALUE self) {
         nullable_cstr_arg(arg_host),
         &ssl_error);
 
-    if (ssl_context == NULL || ssl_error != 0) {
+    if (ssl_context == NULL || ssl_error != REDIS_SSL_CTX_NONE) {
          rb_raise(rb_eRuntimeError, "error creating SSL context: %s",
             (ssl_error != 0) ? redisSSLContextGetError(ssl_error) : "unknown error");
     }

--- a/ext/hiredis_ext/extconf.rb
+++ b/ext/hiredis_ext/extconf.rb
@@ -1,10 +1,43 @@
 require 'mkmf'
 
+openssl_include_dir, openssl_lib_dir = dir_config('openssl')
+
 build_hiredis = true
+
+with_ssl = with_config('ssl', true)
+
 unless have_header('sys/socket.h')
   puts "Could not find <sys/socket.h> (Likely Windows)."
   puts "Skipping building hiredis. The slower, pure-ruby implementation will be used instead."
   build_hiredis = false
+end
+
+def find_openssl_library
+  return false unless find_header("openssl/ssl.h")
+
+  ret = find_library("crypto", "CRYPTO_malloc") &&
+    find_library("ssl", "SSL_new")
+
+  return ret if ret
+
+  false
+end
+
+if with_ssl
+  Logging.message "=== Checking for SSL... ===\n"
+  pkg_config_found = pkg_config("openssl") && find_header("openssl/ssl.h")
+
+  if !pkg_config_found && !find_openssl_library
+    use_ssl = false
+
+    Logging.message "=== SSL not found, skipping rediss:// support. ===\n"
+    Logging.message "Makefile wasn't created. Fix the errors above.\n"
+
+    raise "OpenSSL library could not be found.\n"
+      "You can disable SSL support using the --without-ssl option. " \
+      "You might want to use --with-openssl-dir=<dir> option to specify the prefix where OpenSSL " \
+      "is installed."
+  end
 end
 
 RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
@@ -27,15 +60,22 @@ else
 end
 
 if build_hiredis
+  build_cflags = "-I#{openssl_include_dir}" if openssl_include_dir
+  build_ldflags = "-L#{openssl_lib_dir}" if openssl_lib_dir
+  # Set the prefix to ensure we don't mix and match headers or libraries
+  prefix = File.dirname(openssl_include_dir) if openssl_include_dir
+  ssl_make_arg = "USE_SSL=1 CFLAGS=#{build_cflags} SSL_LDFLAGS=#{build_ldflags} OPENSSL_PREFIX=#{prefix}" if with_ssl
+
   # Make sure hiredis is built...
   Dir.chdir(hiredis_dir) do
-    success = system("#{make_program} static")
+    success = system("#{ssl_make_arg} #{make_program} static")
     raise "Building hiredis failed" if !success
   end
 
   # Statically link to hiredis (mkmf can't do this for us)
   $CFLAGS << " -I#{hiredis_dir}"
   $LDFLAGS << " #{hiredis_dir}/libhiredis.a"
+  $LDFLAGS << " #{hiredis_dir}/libhiredis_ssl.a" if with_ssl
 
   have_func("rb_thread_fd_select")
   create_makefile('hiredis/ext/hiredis_ext')


### PR DESCRIPTION
To do:

1. Currently if SSL peer verification fails, this C extension seg faults in ` rb_sys_fail(0)`. This C extension should never seg fault.
2. Disable SSL peer verification if no certificates are configured. Requires https://github.com/redis/hiredis/pull/1085.
3. Update vendored hiredis-rb with those changes.
4. Update redis-rb with this change:

```diff
diff --git a/lib/redis/connection/hiredis.rb b/lib/redis/connection/hiredis.rb
index 1dbb6a3..5d23600 100644
--- a/lib/redis/connection/hiredis.rb
+++ b/lib/redis/connection/hiredis.rb
@@ -15,6 +15,8 @@ class Redis
 
         if config[:scheme] == "unix"
           connection.connect_unix(config[:path], connect_timeout)
+        elsif config[:scheme] == "rediss" || config[:ssl]
+          connection.connect_ssl(config[:host], config[:port], connect_timeout, config[:ssl_params])
         else
           connection.connect(config[:host], config[:port], connect_timeout)
         end
```