### PR TITLE
Remove testing of older Ruby versions and add latest versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: [2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, jruby]
+        ruby: [3.1, 3.0, 2.7, jruby]
     runs-on: ${{ matrix.os }}
     services:
       redis:


### PR DESCRIPTION
Per https://www.ruby-lang.org/en/downloads/branches, Ruby 1.9 through
2.6 have already reached end-of-life.

Add testing for Ruby 3.0 and 3.1.