### PR TITLE
Add TruffleRuby head on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        ruby: [3.1, 3.0, 2.7, jruby]
+        ruby: [3.1, 3.0, 2.7, jruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     services:
       redis:


### PR DESCRIPTION
Now tests seem pass successfully.

Previous PR #81. Related issue https://github.com/oracle/truffleruby/issues/2703.